### PR TITLE
added deserialization to ResourceInfo and DemandChunkMessage, changed…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,14 @@ project(TIN_TorrentLikeP2P)
 
 set(CMAKE_CXX_STANDARD 17)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
-
+set(CMAKE_CXX_FLAGS -pthread)
 
 FILE(GLOB_RECURSE TIN_P2P_TORRENTS_SOURCES src/*/*.cpp src/*.cpp)
 ADD_LIBRARY(torrents-objects OBJECT ${TIN_P2P_TORRENTS_SOURCES})
 ADD_EXECUTABLE(tin-p2p-torrents $<TARGET_OBJECTS:torrents-objects> main.cpp)
+
+ADD_EXECUTABLE(DESERIALIZE_TEST
+        src/threads/TorrentClient.cpp test.cpp include/threads/TorrentClient.h)
 TARGET_LINK_LIBRARIES(tin-p2p-torrents pthread)
 
 

--- a/include/structs/Message.h
+++ b/include/structs/Message.h
@@ -6,6 +6,8 @@
 #define MAX_MESSAGE_SIZE HEADER_SIZE+MAX_SIZE_OF_PAYLOAD
 #define CHUNK_SIZE MAX_SIZE_OF_PAYLOAD-3
 
+#include <vector>
+#include <string>
 
 //      NAZWA=KOD                       CO PRZESYLAMY
 enum TcpMessageCode {
@@ -47,6 +49,12 @@ enum ClientCommand {
  struct DemandChunkMessage {
     std::string resourceName;
     std::vector<unsigned int> chunkIndices;
+        //konstruktor domyslny
+    DemandChunkMessage(std::string resourceName="",
+                       std::vector<unsigned int> chunkIndices={}):
+                            resourceName(std::move(resourceName)),
+                            chunkIndices(std::move(chunkIndices)) {}
+
 };
 
 

--- a/include/structs/ResourceInfo.h
+++ b/include/structs/ResourceInfo.h
@@ -8,6 +8,15 @@ struct ResourceInfo {
     unsigned int sizeInBytes;
     std::size_t revokeHash;
     bool isRevoked;
+    ResourceInfo(std::string resourceName="",
+                 unsigned int sizeInBytes=0,
+                 std::size_t revokeHash=0,
+                 bool isRevoked = false):
+                    resourceName(std::move(resourceName)),
+                    sizeInBytes(sizeInBytes),
+                    revokeHash(revokeHash),
+                    isRevoked(isRevoked) {}
+
 };
 
 

--- a/include/threads/TorrentClient.h
+++ b/include/threads/TorrentClient.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <mutex>
 #include <map>
-#include <bits/socket.h>
+#include <sys/socket.h>
 
 #include "../structs/Message.h"
 #include "../structs/ResourceInfo.h"
@@ -18,6 +18,7 @@ public:
     }
 
     void run();
+    void debug(ResourceInfo&);
 
     void signalHandler();
 private:
@@ -95,7 +96,6 @@ private:
 
     void receive(int socket, bool tcp);
 
-
     void handleTcpMessage(char *header, char *payload, int socket);
 
     void handleUdpMessage(char *header, char *payload, sockaddr_in sockaddr);
@@ -114,6 +114,7 @@ private:
         return std::make_pair(address.sin_addr.s_addr, address.sin_port);
     }
 
+
     void demandChunkJob(char *payload, int sockaddr);
 
     void stateBeforeFileTransferJob(char *payload, int sockaddr);
@@ -125,11 +126,18 @@ private:
     void errorWhileReceivingJob(char *payload, int sockaddr);
 
     void errorWhileSendingJob(char *payload, int sockaddr);
-};
 
-void errno_abort(const std::string& header){
-    perror(header.c_str());
-    exit(EXIT_FAILURE);
-}
+
+    //PUBLIC TYLKO NA POTRZEBY DEBUGOWANIA, PO TESTACH MOZNA WYWALIC
+public:
+    //deserialization
+    static ResourceInfo deserializeResource(char *message,
+                                            bool toVector=false,
+                                            int *pointer = nullptr);
+    static std::vector<ResourceInfo> deserializeVectorOfResources(char *message);
+
+    static DemandChunkMessage deserializeChunkMessage(char *message);
+};
+void errno_abort(const std::string& header);
 
 #endif //TIN_TORRENTLIKEP2P_TORRENTCLIENT_H

--- a/test.cpp
+++ b/test.cpp
@@ -9,15 +9,17 @@
 
 int main()
 {
-    char* resourceString =
+    char* resourceVectorString =
                 "testowa_wartosc_nr1;997;112;"
                 "test_nr_2;1;2;"
                 "testTrzeci;2;4;"
                 "TESTCZWARTY__;100000;20000;"
                 "t e s t p i a t y;30;100000;"
                 "tescik szosty ;45;0;"
-                "ten ma sie nie udac nr 7; 43 ; 343;";// niestety sie udal, biale znaki nie przeszkadzaja przy parsowaniu liczb
+                "test             nr 7;43;43;";
 
+    char* resourceString =
+                "wartosc;100;300;";
     char* chunkMsgString =
                 "nazwa;"
                 "13;"
@@ -34,16 +36,11 @@ int main()
 
     TorrentClient klient;
 
+    ResourceInfo dummyResource;
+    DemandChunkMessage message = klient.deserializeChunkMessage(chunkMsgString);
+    ResourceInfo resource = klient.deserializeResource(resourceString);
+    std::vector<ResourceInfo> resourceVector = klient.deserializeVectorOfResources(resourceVectorString);
 
-    try {
-        DemandChunkMessage message = klient.deserializeChunkMessage(chunkMsgString);
-        ResourceInfo resource = klient.deserializeResource(resourceString);
-        std::vector<ResourceInfo> resourceVector = klient.deserializeVectorOfResources(resourceString);
-    }
-    catch(std::exception exception){
-//        std::cout<<"tests failed\n";
-        errno_abort("tests failed");
-    }
     std::cout<<"tests passed!\n";
 
 

--- a/test.cpp
+++ b/test.cpp
@@ -1,0 +1,54 @@
+//
+// Created by igor on 6/1/21.
+//
+
+#include "include/structs/Message.h"
+#include "include/structs/ResourceInfo.h"
+#include "include/threads/TorrentClient.h"
+#include <iostream>
+
+int main()
+{
+    char* resourceString =
+                "testowa_wartosc_nr1;997;112;"
+                "test_nr_2;1;2;"
+                "testTrzeci;2;4;"
+                "TESTCZWARTY__;100000;20000;"
+                "t e s t p i a t y;30;100000;"
+                "tescik szosty ;45;0;"
+                "ten ma sie nie udac nr 7; 43 ; 343;";// niestety sie udal, biale znaki nie przeszkadzaja przy parsowaniu liczb
+
+    char* chunkMsgString =
+                "nazwa;"
+                "13;"
+                "14;"
+                "0;"
+                "23;"
+                "997;"
+                "21235432;"
+                "997;"
+                "112;"
+                "1;"
+                "2137;"
+                "3;";
+
+    TorrentClient klient;
+
+
+    try {
+        DemandChunkMessage message = klient.deserializeChunkMessage(chunkMsgString);
+        ResourceInfo resource = klient.deserializeResource(resourceString);
+        std::vector<ResourceInfo> resourceVector = klient.deserializeVectorOfResources(resourceString);
+    }
+    catch(std::exception exception){
+//        std::cout<<"tests failed\n";
+        errno_abort("tests failed");
+    }
+    std::cout<<"tests passed!\n";
+
+
+
+return 0;
+}
+
+


### PR DESCRIPTION
Zmieniłem CMakeLists.txt  - dodałem w nim target dla siebie do testowania oraz flagę: "set(CMAKE_CXX_FLAGS -pthread)",  bez której mi się to w ogóle nie kompilowało.
W 'TorrentClient.h' kompilator pluł się, że dopóki jest <bits/socket.h> a nie <sys/socket.h> to mi tego nie skompiluje (error a nie warning) i sam zaproponował taką zmianę w includzie.
Deserializacje zostały dodane i przetestowane w sposób jaki widać w pliku test.cpp (trochę biednie wiem XD). Jak na razie wygląda na to, że działają dobrze, wszelkie błędy są zgłaszane w funkcjach deserializuących od razu - rzuczają std::runtime_error z w miarę odpowiednim komunikatem.
